### PR TITLE
Add an example to build child scope with dynamic dependencies based on existing support from Motif.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,5 +27,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     annotationProcessor 'com.uber.motif:motif-compiler:0.3.1'
+
+    testAnnotationProcessor 'com.uber.motif:motif-compiler:0.3.1'
+    testImplementation 'com.google.truth:truth:1.0.1'
     implementation 'com.uber.motif:motif:0.3.1'
 }

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/ChildScope.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/ChildScope.java
@@ -1,0 +1,15 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+@motif.Scope
+public interface ChildScope {
+
+    SampleInterface sampleInterface();
+
+    @motif.Objects
+    abstract class Objects {
+
+        abstract SampleInterface bind(SampleImplementation impl);
+
+        abstract SampleImplementation impl();
+    }
+}

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/ConsumerExample.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/ConsumerExample.java
@@ -1,0 +1,22 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class ConsumerExample {
+    @Test
+    public void build_childScope() {
+        DynamicData dynamicData1 = new DynamicData();
+        DynamicData dynamicData2 = new DynamicData();
+        {
+            ChildScope childScope = new SampleScopeImpl().childScope(dynamicData1);
+            assertThat(childScope.sampleInterface().dynamicData()).isEqualTo(dynamicData1);
+        }
+
+        {
+            ChildScope childScope = new SampleScopeImpl().childScope(dynamicData2);
+            assertThat(childScope.sampleInterface().dynamicData()).isEqualTo(dynamicData2);
+        }
+    }
+}

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/DynamicData.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/DynamicData.java
@@ -1,0 +1,4 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+public class DynamicData {
+}

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/Logger.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/Logger.java
@@ -1,0 +1,4 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+public class Logger {
+}

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/SampleImplementation.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/SampleImplementation.java
@@ -1,0 +1,17 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+public class SampleImplementation implements SampleInterface {
+
+    private final DynamicData dynamicData;
+    private final Logger logger;
+
+    public SampleImplementation(DynamicData dynamicData, Logger logger) {
+        this.dynamicData = dynamicData;
+        this.logger = logger;
+    }
+
+    @Override
+    public DynamicData dynamicData() {
+        return dynamicData;
+    }
+}

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/SampleInterface.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/SampleInterface.java
@@ -1,0 +1,6 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+public interface SampleInterface {
+
+    DynamicData dynamicData();
+}

--- a/app/src/test/java/com/tonytangandroid/motif/assist/workaround/SampleScope.java
+++ b/app/src/test/java/com/tonytangandroid/motif/assist/workaround/SampleScope.java
@@ -1,0 +1,17 @@
+package com.tonytangandroid.motif.assist.workaround;
+
+@motif.Scope
+public interface SampleScope {
+
+    ChildScope childScope(DynamicData dynamicData);
+
+    @motif.Objects
+    abstract class Objects {
+
+        @motif.Expose
+        static Logger loggerFromParent() {
+            return new Logger();
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request demons the approach of binding `SampleInterface` with `SampleImplementation` in child scope and let Motif itself to figure out what's need to be provided in creating the `SampleImplementation`.